### PR TITLE
Fix/search by language code and expose manifest timestamp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,13 @@ export default class OtaClient {
     }
 
     /**
+     * List timestamp in distribution
+     */
+    async getManifestTimestamp() {
+        return (await this.manifest).timestamp;
+    }
+
+    /**
      * List of files in distribution
      */
     async listFiles(): Promise<string[]> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ export default class OtaClient {
     }
 
     /**
-     * List timestamp in distribution
+     * List manifest timestamp of distribution
      */
     async getManifestTimestamp(): Promise<number> {
         return (await this.manifest).timestamp;

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ export default class OtaClient {
     }
 
     /**
-     * List manifest timestamp of distribution
+     * Get manifest timestamp of distribution
      */
     async getManifestTimestamp(): Promise<number> {
         return (await this.manifest).timestamp;

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ export default class OtaClient {
     /**
      * List timestamp in distribution
      */
-    async getManifestTimestamp() {
+    async getManifestTimestamp(): Promise<number> {
         return (await this.manifest).timestamp;
     }
 

--- a/src/internal/util/exportPattern.ts
+++ b/src/internal/util/exportPattern.ts
@@ -2729,7 +2729,7 @@ export function includesLanguagePlaceholders(str: string): boolean {
 }
 
 export function replaceLanguagePlaceholders(str: string, languageCode: string): string {
-    const language = languages.find(l => l.twoLettersCode === languageCode);
+    const language = languages.find(l => l.twoLettersCode === languageCode || l.locale === languageCode);
     if (!language) {
         throw new Error(`Unsupported language code : ${languageCode}`);
     }

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -2,6 +2,7 @@ import * as nock from 'nock';
 import OtaClient, { Manifest } from '../src/index';
 
 describe('OTA client', () => {
+    const now = Date.now();
     let scope: nock.Scope;
     const languageCode = 'uk';
     const hash = 'testHash';
@@ -13,7 +14,7 @@ describe('OTA client', () => {
     const manifest: Manifest = {
         files: [filePath],
         languages: [languageCode],
-        timestamp: Date.now(),
+        timestamp: now,
     };
     const jsonFilePath1 = '/folder/file1.json';
     const jsonFilePath2 = '/folder/file2.json';
@@ -30,7 +31,7 @@ describe('OTA client', () => {
     const manifestWithJsonFiles: Manifest = {
         files: [jsonFilePath1, jsonFilePath2],
         languages: [languageCode],
-        timestamp: Date.now(),
+        timestamp: now,
     };
 
     beforeAll(() => {
@@ -60,6 +61,12 @@ describe('OTA client', () => {
         expect(client.getCurrentLocale()).toBeUndefined();
         client.setCurrentLocale(languageCode);
         expect(client.getCurrentLocale()).toBe(languageCode);
+    });
+
+    it('should return manifest timestamp', async () => {
+        const timestamp = await client.getManifestTimestamp();
+        expect(timestamp).toEqual(manifest.timestamp);
+        expect(timestamp).toEqual(now);
     });
 
     it('should return list of files from manifest', async () => {

--- a/tests/internal/util/exportPattern.spec.ts
+++ b/tests/internal/util/exportPattern.spec.ts
@@ -13,13 +13,18 @@ describe('Export Pattern Util', () => {
         const str2 = '/%language%/%two_letters_code%/file2.csv';
         const str3 = '/%locale_with_underscore%/%android_code%/file3.csv';
         const str4 = '/%osx_code%/%osx_locale%/file4.csv';
+        const str5 = '/%language%/%two_letters_code%/%locale%/file5.csv';
+        const str6 = '/%language%/%locale_with_underscore%/%two_letters_code%/%locale%/file6.csv';
         expect(replaceLanguagePlaceholders(str1, 'uk')).toBe('/folder/uk-UA/ukr/file1.csv');
         expect(replaceLanguagePlaceholders(str2, 'es')).toBe('/Spanish/es/file2.csv');
         expect(replaceLanguagePlaceholders(str3, 'en')).toBe('/en_US/en-rUS/file3.csv');
         expect(replaceLanguagePlaceholders(str4, 'de')).toBe('/de.lproj/de/file4.csv');
+        expect(replaceLanguagePlaceholders(str5, 'es-US')).toBe('/Spanish, United States/es/es-US/file5.csv');
+        expect(replaceLanguagePlaceholders(str6, 'en-GB')).toBe('/English, United Kingdom/en_GB/en/en-GB/file6.csv');
     });
 
     it('should throw error for invalid language code', () => {
         expect(() => replaceLanguagePlaceholders('test', 'invalidLang')).toThrowError();
+        expect(() => replaceLanguagePlaceholders('test', 'pt-PT')).not.toThrowError();
     });
 });


### PR DESCRIPTION
Expose Manifest timestamp.
- This could be useful to know when we should pull new translations or use the cached ones.

Search by language code.
- When calling `listLanguages()` I have the English language as `en-GB` and `en-US`. With current implementation is only possible to get the default English translation (with the twoLetterCode = 'en')
- When calling `getTranslations()` it fails because does not find a match for the different English languages.
- Searching by locale as well allows getting different translations for the same language and working as expected.