### PR TITLE
update stringsCache to use language

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ export default class OtaClient {
     private manifestHolder?: Promise<Manifest>;
     private disableManifestCache = false;
 
-    private stringsCache: { [file: string]: Promise<any> } = {};
+    private stringsCache: { [file: string]: { [language: string]: Promise<any> } } = {};
     private disableStringsCache = false;
 
     private disableJsonDeepMerge = false;
@@ -273,13 +273,16 @@ export default class OtaClient {
         let strings = {};
         for (const filePath of files) {
             let content;
-            if (!!this.stringsCache[filePath]) {
-                content = await this.stringsCache[filePath];
+            if (!!(this.stringsCache[filePath] || {})[language]) {
+                content = await this.stringsCache[filePath][language];
             } else {
                 if (!this.disableStringsCache) {
-                    this.stringsCache[filePath] = this.getFileTranslations(filePath, language);
+                    this.stringsCache[filePath] = {
+                        ...this.stringsCache[filePath],
+                        [language]: this.getFileTranslations(filePath, language),
+                    };
                 }
-                content = await this.stringsCache[filePath];
+                content = await this.stringsCache[filePath][language];
             }
             if (this.disableJsonDeepMerge) {
                 strings = { ...strings, ...content };


### PR DESCRIPTION
Hi team! Thank you for the nice library :)

I found a small issue when integrating with this - all translations returned are the same language when calling the `getStrings` function, and calling `getStringsByLocale` multiple times with different locales returns translations with the first locale used.

It appears that the stringsCache uses filename as the cache key, however this also means that the cached file is served no matter which language is being requested (even if the cached file is in a different language)

This PR adds languages to the stringsCache to fix this.



