### PR TITLE
fix: correctly set null types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,8 +38,9 @@ export interface Manifest {
     files: string[];
     languages: string[];
     timestamp: number;
-    language_mapping?: LanguageMappings;
-    custom_languages?: CustomLanguages;
+    // these next two arrays will always be empty if they are arrays, the never type just avoids an eslint error
+    language_mapping: LanguageMappings | never[];
+    custom_languages: CustomLanguages | never[];
 }
 
 export interface LanguageMappings {
@@ -150,15 +151,19 @@ export default class OtaClient {
     /**
      * Language mappings
      */
-    async getLanguageMappings(): Promise<LanguageMappings | undefined> {
-        return (await this.manifest).language_mapping;
+    async getLanguageMappings(): Promise<LanguageMappings | null> {
+        const languageMappings = (await this.manifest).language_mapping;
+        // languageMappings will be an empty array if there are none, or an object of the provided type otherwise
+        return Array.isArray(languageMappings) ? null : languageMappings;
     }
 
     /**
      * Custom languages
      */
-    async getCustomLanguages(): Promise<CustomLanguages | undefined> {
-        return (await this.manifest).custom_languages;
+    async getCustomLanguages(): Promise<CustomLanguages | null> {
+        const customLanguages = (await this.manifest).custom_languages;
+        // customLanguages will be an empty array if there are none, or an object of the provided type otherwise
+        return Array.isArray(customLanguages) ? null : customLanguages;
     }
 
     /**

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -16,12 +16,14 @@ describe('OTA client', () => {
         files: [filePath],
         languages: [languageCode],
         timestamp: now,
-        /*eslint-disable-next-line @typescript-eslint/camelcase*/
+        /* eslint-disable @typescript-eslint/camelcase */
         language_mapping: {
             uk: {
                 locale: customLanguageLocale,
             },
         },
+        custom_languages: [],
+        /* eslint-enable @typescript-eslint/camelcase */
     };
     const jsonFilePath1 = '/folder/file1.json';
     const jsonFilePath2 = '/folder/file2.json';
@@ -39,6 +41,10 @@ describe('OTA client', () => {
         files: [jsonFilePath1, jsonFilePath2],
         languages: [languageCode],
         timestamp: now,
+        /* eslint-disable @typescript-eslint/camelcase */
+        language_mapping: [],
+        custom_languages: [],
+        /* eslint-enable @typescript-eslint/camelcase */
     };
 
     beforeAll(() => {


### PR DESCRIPTION
This PR correctly handles the lack of language_mapping and custom_languages as these are never optional but rather default to an empty array on the CDN. This is a very odd behavior that should be fixed but while it's not, have this fix here
This also improves performance slightly by removing unnecessary awaits and using for loops instead of Promise.all, as the advantages of said method weren't being fully used and were causing a bigger burden