### PR TITLE
refactor: drop support for node 10 and add support for 16

### DIFF
--- a/ci/templates/jobs.yml
+++ b/ci/templates/jobs.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       maxParallel: 4
       matrix:
+        node-16:
+          node_version: ^16.13.2
         node-14:
-          node_version: ^14.15.0
+          node_version: ^14.18.3
         node-12:
-          node_version: ^12.2.0
-        node-10:
-          node_version: ^10.10.0
+          node_version: ^12.22.9
     steps:
       - task: NodeTool@0
         inputs:

--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
   "homepage": "https://github.com/crowdin/ota-client-js#readme",
   "directories": {
     "test": "tests"
+  },
+  "engines": {
+    "node": ">=12.9.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,8 +207,8 @@ export default class OtaClient {
         const language = this.getLanguageCode(languageCode);
         const languageMappings = await this.getLanguageMappings();
         const customLanguages = await this.getCustomLanguages();
-        const languageMapping = (languageMappings || {})[language];
-        const customLanguage = (customLanguages || {})[language];
+        const languageMapping = (languageMappings ?? {})[language];
+        const customLanguage = (customLanguages ?? {})[language];
         if (includesLanguagePlaceholders(file)) {
             url += replaceLanguagePlaceholders(file, language, languageMapping, customLanguage);
         } else {
@@ -264,7 +264,7 @@ export default class OtaClient {
         }
         let res = strings[firstKey];
         for (const keyPart of path) {
-            res = res && res[keyPart];
+            res = res?.[keyPart];
         }
         return res;
     }
@@ -280,8 +280,9 @@ export default class OtaClient {
         let strings = {};
         for (const filePath of files) {
             let content;
-            if (!!(this.stringsCache[filePath] || {})[language]) {
-                content = await this.stringsCache[filePath][language];
+            const fileCache = await (this.stringsCache[filePath] ?? {})[language];
+            if (fileCache) {
+                content = fileCache;
             } else {
                 if (!this.disableStringsCache) {
                     this.stringsCache[filePath] = {

--- a/src/internal/util/exportPattern.ts
+++ b/src/internal/util/exportPattern.ts
@@ -18,7 +18,7 @@ const languagePlaceholders: { [placeholder: string]: Mapper<Language, string> } 
     '%two_letters_code%': lang => lang.twoLettersCode,
     '%three_letters_code%': lang => lang.threeLettersCode,
     '%locale%': lang => lang.locale,
-    '%locale_with_underscore%': lang => lang.localeWithUnderscore || lang.locale.replace(/-/g, '_'),
+    '%locale_with_underscore%': lang => lang.localeWithUnderscore ?? lang.locale.replace(/-/g, '_'),
     '%android_code%': lang => lang.androidCode,
     '%osx_code%': lang => lang.osxCode,
     '%osx_locale%': lang => lang.osxLocale,

--- a/src/internal/util/strings.ts
+++ b/src/internal/util/strings.ts
@@ -1,5 +1,5 @@
 export function isJsonFile(file: string): boolean {
-    const extension = (file || '').split('.').pop();
+    const extension = (file ?? '').split('.').pop();
     return extension?.toLocaleLowerCase() === 'json';
 }
 
@@ -8,8 +8,8 @@ function isObject(value: any): boolean {
 }
 
 export function mergeDeep(targetObj: any, sourceObj: any): any {
-    const target = targetObj || {};
-    const source = sourceObj || {};
+    const target = targetObj ?? {};
+    const source = sourceObj ?? {};
     Object.keys(source).forEach(key => {
         if (isObject(source[key])) {
             if (!(key in target)) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,10 @@
     "compilerOptions": {
         "module": "commonjs",
         "declaration": true,
-        "target": "es6",
+        "target": "es2019",
         "outDir": "./out",
         "lib": [
-            "es6",
+            "es2021",
             "DOM"
         ],
         "strict": true


### PR DESCRIPTION
This PR drops support for any version of node below Node 12 (the oldest version in maintenance mode) and changes CI to run on the latest versions of Node 12, 14 and 16. This also changes the target ES version to es2019 (the latest supported in node 12) and changes the lib to es2021 (the latest available in node 16). Due to how Typescript works, the project will compile to es2019, thus supporting older versions while still allowing us to write source code with recent features.
Lastly, I also changed some places in the code where new features could be used and changed package.json to specify the "engines.node" field. I also noticed package-lock.json was built before npm v7 (latest version is v8.4.0), so I highly recommend updating that, but I will leave that up to maintainers and can include that in this PR if you wish