### PR TITLE
feat: add methods for replacing placeholders

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
         "@typescript-eslint/no-explicit-any": 1,
         "@typescript-eslint/explicit-function-return-type": 2,
         "@typescript-eslint/no-namespace": 0,
+        "@typescript-eslint/no-non-null-assertion": "off",
         "no-unused-expressions": 2,
         "curly": 2,
 		"semi": 2,

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ Also there are several helper methods.
 | `getManifestTimestamp`       | Get manifest timestamp of distribution | |
 | `listFiles`                  | List of files in distribution | |
 | `listLanguages`              | List of project language codes | |
+| `getReplacedLanguages`       | List of project language codes in the provided format | `format` (placeholder format you want to replace your languages with, e.g. `locale`) |
+| `getReplacedFiles`           | List of files in distribution with variables replaced with the corresponding language code | |
+| `getLanguageObjects`         | List of project language objects | |
 | `clearStringsCache`          | Clear cache of translation strings | |
 | `getLanguageMappings`        | Get project language mapping | |
 | `getCustomLanguages`         | Get project custom languages | |
@@ -163,7 +166,7 @@ const hash = '{distribution_hash}';
 
 const client = new otaClient(hash);
 
-// will return all translation strings for all languages from all json files 
+// will return all translation strings for all languages from all json files
 client.getStrings()
   .then(res => {
     //get needed translation by language + key
@@ -224,8 +227,8 @@ If you've found an error in these samples, please [Contact Customer Success Serv
 
 ## License
 <pre>
-The Crowdin OTA JavaScript client is licensed under the MIT License. 
-See the LICENSE.md file distributed with this work for additional 
+The Crowdin OTA JavaScript client is licensed under the MIT License.
+See the LICENSE.md file distributed with this work for additional
 information regarding copyright ownership.
 
 Except as contained in the LICENSE file, the name(s) of the above copyright

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,6 +202,9 @@ export default class OtaClient {
         return result;
     }
 
+    /**
+     * List of project language objects
+     */
     async getLanguageObjects(): Promise<Language[]> {
         const languages = await this.listLanguages();
         const customLanguages = await this.getCustomLanguages();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,12 @@
 import { AxiosHttpClient } from './internal/http/axiosClient';
-import { includesLanguagePlaceholders, replaceLanguagePlaceholders } from './internal/util/exportPattern';
+import {
+    findLanguageObject,
+    includesLanguagePlaceholders,
+    Language,
+    LanguagePlaceholders,
+    languagePlaceholders,
+    replaceLanguagePlaceholders,
+} from './internal/util/exportPattern';
 import { isJsonFile, mergeDeep } from './internal/util/strings';
 
 export interface ClientConfig {
@@ -64,11 +71,16 @@ export interface LanguageTranslations {
     content: string | any | null;
 }
 
+export interface LanguageFiles {
+    [languageCode: string]: string[];
+}
+
 export interface LanguageStrings {
     [languageCode: string]: any;
 }
 
 export interface CustomLanguage {
+    name: string;
     two_letters_code: string;
     three_letters_code: string;
     locale: string;
@@ -146,6 +158,54 @@ export default class OtaClient {
      */
     async listLanguages(): Promise<string[]> {
         return (await this.manifest).languages;
+    }
+
+    /**
+     * List of project language codes in the provided format
+     * @param format The placeholder format you want to replace your languages with
+     */
+    async getReplacedLanguages(format: LanguagePlaceholders): Promise<string[]> {
+        const [languages, customLanguages] = await Promise.all([
+            await this.listLanguages(),
+            await this.getCustomLanguages(),
+        ]);
+
+        return languages.map(l => languagePlaceholders[format](findLanguageObject(l, customLanguages?.[l])));
+    }
+
+    /**
+     * List of files in distribution with variables replaced with the corresponding language code
+     */
+    async getReplacedFiles(): Promise<LanguageFiles> {
+        const [customLanguages, languageMappings, files, languages] = await Promise.all([
+            await this.getCustomLanguages(),
+            await this.getLanguageMappings(),
+            await this.listFiles(),
+            await this.listLanguages(),
+        ]);
+
+        const result: Record<string, string[]> = {};
+        await Promise.all(
+            languages.map(async language => {
+                result[language] = await Promise.all(
+                    files.map(file =>
+                        replaceLanguagePlaceholders(
+                            file,
+                            language,
+                            languageMappings?.[language],
+                            customLanguages?.[language],
+                        ),
+                    ),
+                );
+            }),
+        );
+        return result;
+    }
+
+    async getLanguageObjects(): Promise<Language[]> {
+        const languages = await this.listLanguages();
+        const customLanguages = await this.getCustomLanguages();
+        return Promise.all(languages.map(language => findLanguageObject(language, customLanguages?.[language])!));
     }
 
     /**

--- a/tests/internal/util/exportPattern.spec.ts
+++ b/tests/internal/util/exportPattern.spec.ts
@@ -23,6 +23,7 @@ describe('Export Pattern Util', () => {
             locale: 'ua',
         };
         const customLanguage: CustomLanguage = {
+            name: 'Test Language',
             /*eslint-disable-next-line @typescript-eslint/camelcase*/
             two_letters_code: 'tl',
             /*eslint-disable-next-line @typescript-eslint/camelcase*/


### PR DESCRIPTION
This PR adds 3 new methods to the library to make it easier to retrieve raw data such as replaced URLs, full language objects and language codes in a specific format. Tests for all methods were added and are passing, but if you think there are better ways to implement these methods, please let me know!