### PR TITLE
fix: no request sent when `disableStringsCache:true`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -218,10 +218,10 @@ export default class OtaClient {
         let strings = {};
         for (const filePath of files) {
             let content;
-            if (!!this.stringsCache[filePath]) {
-                content = await this.stringsCache[filePath];
+            if (this.disableStringsCache) {
+                content = await this.getFileTranslations(filePath);
             } else {
-                if (!this.disableStringsCache) {
+                if (!this.stringsCache[filePath]) {
                     this.stringsCache[filePath] = this.getFileTranslations(filePath);
                 }
                 content = await this.stringsCache[filePath];


### PR DESCRIPTION
In the origin code, if `disableStringsCache` is set to `true`, the `getFileTranslations` will never be called.