### PR TITLE
ci: switch npm publish workflow to staged publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Publish 'latest'
         if: ${{ github.event.action == 'released' }}
-        run: npm publish --provenance
+        run: npm stage publish --provenance
 
       - name: Publish 'next'
         if: ${{ github.event.action == 'prereleased' }}
-        run: npm publish --tag next --provenance
+        run: npm stage publish --tag next --provenance


### PR DESCRIPTION
Switched the npm release workflow to staged publishing (npm stage publish). This adds an approval gate before a version becomes installable, reducing supply-chain risk while keeping our CI release flow unchanged otherwise.